### PR TITLE
chore(package.json): fix directory path of 'main' configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "v1.0.4",
   "description": "A JavaScript wrapper package for The Movie Database API.",
   "main": "./src/tmdb-js/tmdb-js.js",
+  "private": true,
   "scripts": {
     "test": "mocha test/test.js --timeout 30000"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "v1.0.4",
   "description": "A JavaScript wrapper package for The Movie Database API.",
   "main": "./src/tmdb-js/tmdb-js.js",
-  "private": true,
   "scripts": {
     "test": "mocha test/test.js --timeout 30000"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tmdb-js-wrapper",
   "version": "v1.0.4",
   "description": "A JavaScript wrapper package for The Movie Database API.",
-  "main": "src/tmdbjs/tmdbjs.js",
+  "main": "./src/tmdb-js/tmdb-js.js",
   "scripts": {
     "test": "mocha test/test.js --timeout 30000"
   },


### PR DESCRIPTION
Noticed the dir path in the package.json is pointing incorrectly, leading to module import concerns should the user just opt to write

```JS
import { TmdbClient } from 'tmdb-js-wrapper'
```

Implemented the little dirpath fix in light of this.